### PR TITLE
[fix] chart.pyのフォント設定をクロスプラットフォーム対応にする

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Japanese fonts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq fonts-noto-cjk
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/src/chart.py
+++ b/src/chart.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import platform
 from datetime import date, datetime
 from pathlib import Path
 from typing import List, Optional
@@ -20,8 +21,20 @@ import matplotlib.dates as mdates
 from matplotlib.figure import Figure
 
 
-# 日本語フォント設定（macOS）
-plt.rcParams['font.family'] = ['Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'sans-serif']
+def _get_japanese_font_families() -> list[str]:
+    """OSに応じた日本語フォントファミリーのリストを返す"""
+    system = platform.system()
+    if system == "Darwin":
+        return ["Hiragino Sans", "Hiragino Kaku Gothic ProN", "sans-serif"]
+    elif system == "Linux":
+        return ["Noto Sans CJK JP", "IPAGothic", "sans-serif"]
+    elif system == "Windows":
+        return ["Yu Gothic", "MS Gothic", "Meiryo", "sans-serif"]
+    return ["sans-serif"]
+
+
+# 日本語フォント設定（クロスプラットフォーム対応）
+plt.rcParams['font.family'] = _get_japanese_font_families()
 plt.rcParams['axes.unicode_minus'] = False
 
 


### PR DESCRIPTION
## Summary
- OS判定でフォントを切り替えるヘルパー関数 `_get_japanese_font_families()` を追加
- macOS: Hiragino Sans / Linux: Noto Sans CJK JP / Windows: Yu Gothic
- GitHub Actionsに `fonts-noto-cjk` パッケージのインストールステップを追加

## Test plan
- [ ] macOSでグラフ生成が文字化けしないこと
- [ ] GitHub Actions (Ubuntu) でフォントインストールが成功すること

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)