### PR TITLE
[fix] 例外の握りつぶし箇所にlogging出力を追加する

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,18 @@
 """Oura Ring to Discord Notifier - Main Entry Point"""
 
+import logging
 import os
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
 
 # .envファイルの読み込み（存在する場合のみ）
 try:
@@ -119,7 +127,7 @@ def send_morning_report() -> bool:
         try:
             discord.send_message(f":x: **朝通知エラー**\n```{str(e)}```")
         except Exception:
-            pass
+            logger.error("朝通知のエラー通知送信に失敗しました", exc_info=True)
         return False
 
 
@@ -241,7 +249,7 @@ def send_night_report() -> bool:
         try:
             discord.send_message(f":x: **夜通知エラー**\n```{str(e)}```")
         except Exception:
-            pass
+            logger.error("夜通知のエラー通知送信に失敗しました", exc_info=True)
         return False
 
 

--- a/src/oura_client.py
+++ b/src/oura_client.py
@@ -1,9 +1,12 @@
 """Oura Ring API Client"""
 
+import logging
 import requests
 import time
 from datetime import date, datetime, timedelta
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class OuraClient:
@@ -311,7 +314,7 @@ class OuraClient:
             if data.get("data"):
                 return data["data"][0]
         except Exception:
-            pass
+            logger.warning("ストレスデータの取得に失敗しました", exc_info=True)
         return None
 
     def get_monthly_data(self, end_date: Optional[date] = None, days: int = 30) -> dict:


### PR DESCRIPTION
## Summary
- oura_client.py, main.py, bot.pyに `logging` モジュールを導入
- 9箇所の `except Exception: pass` を `logger.warning/error(..., exc_info=True)` に変更
- main.pyとbot.pyのエントリーポイントに `logging.basicConfig()` を設定

## Test plan
- [ ] 通常実行時にログ出力が正しくフォーマットされること
- [ ] 例外発生時にスタックトレースがログに出力されること

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)