### PR TITLE
[chore] ruff + pytest CIワークフローを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Lint with ruff
+        run: |
+          ruff check src/ tests/
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "oura-discord-notifier"
+requires-python = ">=3.11"
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = [
+    "E501",  # line-length はフォーマッターに任せる
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["oura_client", "formatter", "advice", "chart", "settings", "bot_utils"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+ruff>=0.4.0
+pytest>=7.0.0

--- a/src/bot_utils.py
+++ b/src/bot_utils.py
@@ -2,14 +2,14 @@
 
 import os
 import re
-import discord
-from datetime import date, timedelta, time
-from zoneinfo import ZoneInfo
+from datetime import date, time, timedelta
 from typing import Optional
+from zoneinfo import ZoneInfo
+
+import discord
 
 from oura_client import OuraClient
 from settings import SettingsManager
-
 
 JST = ZoneInfo("Asia/Tokyo")
 

--- a/src/chart.py
+++ b/src/chart.py
@@ -3,9 +3,9 @@
 import io
 import os
 import platform
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 config_dir = Path(__file__).parent.parent / "data" / ".matplotlib"
 try:
@@ -14,11 +14,11 @@ try:
 except OSError:
     pass
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use('Agg')  # GUIバックエンドを使用しない
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-from matplotlib.figure import Figure
+import matplotlib.dates as mdates  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
 
 
 def _get_japanese_font_families() -> list[str]:

--- a/src/cogs/general.py
+++ b/src/cogs/general.py
@@ -1,26 +1,25 @@
 """ヘルプ・自然言語対応"""
 
 import re
+
 import discord
 from discord.ext import commands
-from typing import List
 
+from advice import generate_advice
 from bot_utils import (
-    get_oura_client,
-    get_jst_today,
     create_embed_from_section,
+    get_jst_today,
+    get_oura_client,
     settings,
 )
 from formatter import (
-    format_sleep_section,
-    format_readiness_section,
     format_morning_report,
-    format_noon_report,
     format_night_report,
+    format_noon_report,
+    format_readiness_section,
+    format_sleep_section,
     get_score_emoji,
 )
-from advice import generate_advice
-
 
 # パターン定義
 PATTERNS = [

--- a/src/cogs/health.py
+++ b/src/cogs/health.py
@@ -1,25 +1,26 @@
 """ヘルスデータ照会コマンド"""
 
-import discord
-from discord import app_commands
-from discord.ext import commands
 from datetime import timedelta
 from typing import Optional
 
+import discord
+from discord import app_commands
+from discord.ext import commands
+
 from bot_utils import (
-    get_oura_client,
-    get_jst_today,
-    parse_date,
     create_embed_from_section,
+    get_jst_today,
+    get_oura_client,
+    parse_date,
     settings,
 )
 from formatter import (
-    format_sleep_section,
+    format_duration,
     format_readiness_section,
+    format_sleep_section,
+    format_time_from_iso,
     get_score_emoji,
     get_score_label,
-    format_duration,
-    format_time_from_iso,
 )
 
 

--- a/src/cogs/report.py
+++ b/src/cogs/report.py
@@ -1,25 +1,26 @@
 """レポート・分析コマンド"""
 
+from datetime import date, timedelta
+from typing import List, Optional
+
 import discord
 from discord import app_commands
 from discord.ext import commands
-from datetime import date, timedelta
-from typing import Optional, List
 
+from advice import generate_advice
 from bot_utils import (
-    get_oura_client,
-    get_jst_today,
-    parse_date,
     create_embed_from_section,
+    get_jst_today,
+    get_oura_client,
+    parse_date,
     settings,
 )
+from chart import generate_combined_chart, generate_score_chart, generate_steps_chart
 from formatter import (
     format_morning_report,
-    format_noon_report,
     format_night_report,
+    format_noon_report,
 )
-from advice import generate_advice
-from chart import generate_score_chart, generate_steps_chart, generate_combined_chart
 
 
 class ReportCog(commands.Cog):

--- a/src/cogs/scheduler.py
+++ b/src/cogs/scheduler.py
@@ -2,16 +2,16 @@
 
 import logging
 from datetime import time
+
 from discord.ext import commands, tasks
 
 from bot_utils import (
-    get_oura_client,
     get_jst_now,
     get_jst_today,
+    get_oura_client,
     parse_time_str,
     settings,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/cogs/settings_cog.py
+++ b/src/cogs/settings_cog.py
@@ -1,9 +1,10 @@
 """設定管理コマンド"""
 
+from typing import Optional
+
 import discord
 from discord import app_commands
 from discord.ext import commands
-from typing import Optional
 
 from bot_utils import parse_time_str, settings
 

--- a/src/formatter.py
+++ b/src/formatter.py
@@ -1,8 +1,8 @@
 """Message Formatter for Discord - 朝・昼・夜の通知対応"""
 
 from datetime import datetime
-from zoneinfo import ZoneInfo
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 JST = ZoneInfo("Asia/Tokyo")
 

--- a/src/main.py
+++ b/src/main.py
@@ -24,13 +24,13 @@ try:
 except ImportError:
     pass
 
-from oura_client import OuraClient
-from discord_client import DiscordClient
-from formatter import (
+from discord_client import DiscordClient  # noqa: E402
+from formatter import (  # noqa: E402
     format_morning_report,
-    format_noon_report,
     format_night_report,
+    format_noon_report,
 )
+from oura_client import OuraClient  # noqa: E402
 
 # タイムゾーン
 JST = ZoneInfo("Asia/Tokyo")
@@ -167,7 +167,7 @@ def send_noon_report() -> bool:
         )
 
         if not should_send:
-            print(f"No noon notification needed.")
+            print("No noon notification needed.")
             if activity:
                 print(f"  Steps: {activity.get('steps', 0):,} / Goal pace: OK")
             return True

--- a/src/oura_client.py
+++ b/src/oura_client.py
@@ -1,10 +1,11 @@
 """Oura Ring API Client"""
 
 import logging
-import requests
 import time
 from datetime import date, datetime, timedelta
 from typing import Optional
+
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,10 +1,9 @@
 """設定管理モジュール - JSON永続化"""
 
 import json
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from typing import Any
-
 
 # 設定ファイルパス
 SETTINGS_FILE = Path(__file__).parent.parent / "data" / "settings.json"

--- a/tests/test_bot_utils.py
+++ b/tests/test_bot_utils.py
@@ -1,7 +1,7 @@
 """bot_utils.py のユニットテスト"""
 
-from unittest.mock import patch
 from datetime import date, time
+from unittest.mock import patch
 
 from bot_utils import parse_date, parse_time_str
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,21 +1,20 @@
 """formatter.py のユニットテスト"""
 
-import pytest
 from formatter import (
+    calculate_target_bedtime,
+    format_comparison,
+    format_duration,
+    format_morning_report,
+    format_night_report,
+    format_noon_report,
+    format_readiness_section,
+    format_sleep_section,
+    format_time_from_iso,
+    format_weekly_trend,
+    get_comparison_emoji,
     get_score_emoji,
     get_score_label,
-    get_comparison_emoji,
-    format_comparison,
-    format_weekly_trend,
-    format_duration,
-    format_time_from_iso,
-    calculate_target_bedtime,
     get_today_policy,
-    format_morning_report,
-    format_noon_report,
-    format_night_report,
-    format_sleep_section,
-    format_readiness_section,
 )
 
 

--- a/tests/test_oura_client.py
+++ b/tests/test_oura_client.py
@@ -1,7 +1,7 @@
 """oura_client.py のユニットテスト"""
 
-from unittest.mock import patch, MagicMock
 from datetime import date
+from unittest.mock import MagicMock, patch
 
 from oura_client import OuraClient
 


### PR DESCRIPTION
## Summary
- `pyproject.toml` を新設（ruff設定: line-length=120, select=E,F,W,I）
- `requirements-dev.txt` を新設（pytest + ruff）
- `.github/workflows/ci.yml` を新設（push/PR時にPython 3.11/3.12でlint+test実行）
- 既存コードのruff指摘（未使用import、import順序、不要f-string）を全て修正

## Test plan
- [x] `ruff check src/ tests/` で全チェック通過
- [x] `pytest tests/ -v` で全84テスト通過

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)